### PR TITLE
EXOGTN-2205: Calling logout should be after invalidating the HTTP ses…

### DIFF
--- a/tomcat/tomcat7/src/main/java/org/gatein/wci/tomcat/TC7ServletContainerContext.java
+++ b/tomcat/tomcat7/src/main/java/org/gatein/wci/tomcat/TC7ServletContainerContext.java
@@ -145,7 +145,6 @@ public class TC7ServletContainerContext implements ServletContainerContext, Cont
    public void logout(HttpServletRequest request, HttpServletResponse response) throws ServletException
    {
       HttpSession sess = request.getSession(false);
-      request.logout();
 
       if (sess == null)
          return;
@@ -173,6 +172,7 @@ public class TC7ServletContainerContext implements ServletContainerContext, Cont
          }
 
       }));
+      request.logout();
    }
 
    public String getContainerInfo()


### PR DESCRIPTION
If we call request.logout() the HTTP session will be destroyed without invalidation, a new session will be created and assigned to the current request.. HTTPEventListeners won't be executed and the conversationstate of the user won't be removed. 
The fix will make sure that the session is invalidated before calling request.logout()