### PR TITLE
SWF-3869: Update all PLF components versions to 5.0.x-SNAPSHOT

### DIFF
--- a/glassfish/glassfish3/pom.xml
+++ b/glassfish/glassfish3/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-parent</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
    <modelVersion>4.0.0</modelVersion>
@@ -12,7 +12,7 @@
 
    <dependencies>
       <dependency>
-         <groupId>org.gatein.wci</groupId>
+         <groupId>org.exoplatform.gatein.wci</groupId>
          <artifactId>wci-wci</artifactId>
       </dependency>
       <dependency>

--- a/jboss/jboss7/pom.xml
+++ b/jboss/jboss7/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-jboss</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
 
    <modelVersion>4.0.0</modelVersion>
@@ -12,7 +12,7 @@
 
    <dependencies>
      <dependency>
-       <groupId>org.gatein.wci</groupId>
+       <groupId>org.exoplatform.gatein.wci</groupId>
        <artifactId>wci-wci</artifactId>
      </dependency>
      <dependency>

--- a/jboss/pom.xml
+++ b/jboss/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-parent</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-jboss</artifactId>

--- a/jetty/jetty8/pom.xml
+++ b/jetty/jetty8/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-parent</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
 
@@ -17,7 +17,7 @@
 
    <dependencies>
       <dependency>
-         <groupId>org.gatein.wci</groupId>
+         <groupId>org.exoplatform.gatein.wci</groupId>
          <artifactId>wci-wci</artifactId>
       </dependency>
      <dependency>

--- a/jetty/pom.xml
+++ b/jetty/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-parent</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-jetty</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
 
   <name>GateIn - Web Container Integration</name>
 
-  <groupId>org.gatein.wci</groupId>
+  <groupId>org.exoplatform.gatein.wci</groupId>
   <artifactId>wci-parent</artifactId>
-  <version>2.6.x-PLF-SNAPSHOT</version>
+  <version>5.0.x-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>
@@ -71,50 +71,50 @@
         <version>${version.gatein.common}</version>
       </dependency>
       <dependency>
-        <groupId>org.gatein.wci</groupId>
+        <groupId>org.exoplatform.gatein.wci</groupId>
         <artifactId>wci-wci</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.gatein.wci</groupId>
+        <groupId>org.exoplatform.gatein.wci</groupId>
         <artifactId>wci-tomcat7</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.gatein.wci</groupId>
+        <groupId>org.exoplatform.gatein.wci</groupId>
         <artifactId>wci-jboss7</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.gatein.wci</groupId>
+        <groupId>org.exoplatform.gatein.wci</groupId>
         <artifactId>wci-glassfish3</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.gatein.wci</groupId>
+        <groupId>org.exoplatform.gatein.wci</groupId>
         <artifactId>wci-jetty8</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.gatein.wci</groupId>
+        <groupId>org.exoplatform.gatein.wci</groupId>
         <artifactId>wci-test-core</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.gatein.wci</groupId>
+        <groupId>org.exoplatform.gatein.wci</groupId>
         <artifactId>wci-test-core</artifactId>
         <version>${project.version}</version>
         <type>test-jar</type>
       </dependency>
       <dependency>
-        <groupId>org.gatein.wci</groupId>
+        <groupId>org.exoplatform.gatein.wci</groupId>
         <artifactId>wci-test-core</artifactId>
         <version>${project.version}</version>
         <type>test-jar</type>
         <classifier>test-sources</classifier>
       </dependency>
       <dependency>
-        <groupId>org.gatein.wci</groupId>
+        <groupId>org.exoplatform.gatein.wci</groupId>
         <artifactId>wci-test-jboss7-dependencies</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/test/core/pom.xml
+++ b/test/core/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-parent</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-test-core</artifactId>
@@ -12,7 +12,7 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-wci</artifactId>
     </dependency>
     <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-parent</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-test-parent</artifactId>

--- a/test/servers/glassfish3/pom.xml
+++ b/test/servers/glassfish3/pom.xml
@@ -1,9 +1,9 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-servers</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-test-glassfish3</artifactId>
@@ -12,15 +12,15 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-glassfish3</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-core</artifactId>
       <type>test-jar</type>
     </dependency>

--- a/test/servers/jboss7/dependencies/pom.xml
+++ b/test/servers/jboss7/dependencies/pom.xml
@@ -1,9 +1,9 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-jboss7</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-test-jboss7-dependencies</artifactId>
@@ -12,7 +12,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-jboss7</artifactId>
     </dependency>
   </dependencies>

--- a/test/servers/jboss7/pom.xml
+++ b/test/servers/jboss7/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-servers</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-test-jboss7</artifactId>

--- a/test/servers/jboss7/run/pom.xml
+++ b/test/servers/jboss7/run/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-jboss7</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-test-jboss7-run</artifactId>
@@ -12,24 +12,24 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-core</artifactId>
       <type>test-jar</type>
     </dependency>
 
     <!-- -->
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-jboss7</artifactId>
     </dependency>
 
     <!-- We import this pom that contains the dependencies embedded in the test -->
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-jboss7-dependencies</artifactId>
     </dependency>
 

--- a/test/servers/jetty8/pom.xml
+++ b/test/servers/jetty8/pom.xml
@@ -1,9 +1,9 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-servers</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-test-jetty8</artifactId>
@@ -12,15 +12,15 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-jetty8</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-core</artifactId>
       <type>test-jar</type>
     </dependency>

--- a/test/servers/pom.xml
+++ b/test/servers/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-parent</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-test-servers</artifactId>

--- a/test/servers/tomcat7/pom.xml
+++ b/test/servers/tomcat7/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-servers</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-test-tomcat7</artifactId>
@@ -12,18 +12,18 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-test-core</artifactId>
       <type>test-jar</type>
     </dependency>
 
     <!-- -->
     <dependency>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-tomcat7</artifactId>
     </dependency>
 

--- a/tomcat/pom.xml
+++ b/tomcat/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-parent</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-tomcat</artifactId>

--- a/tomcat/tomcat7/pom.xml
+++ b/tomcat/tomcat7/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <parent>
-      <groupId>org.gatein.wci</groupId>
+      <groupId>org.exoplatform.gatein.wci</groupId>
       <artifactId>wci-tomcat</artifactId>
-      <version>2.6.x-PLF-SNAPSHOT</version>
+      <version>5.0.x-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>wci-tomcat7</artifactId>
@@ -11,7 +11,7 @@
 
    <dependencies>
       <dependency>
-         <groupId>org.gatein.wci</groupId>
+         <groupId>org.exoplatform.gatein.wci</groupId>
          <artifactId>wci-wci</artifactId>
       </dependency>
       <dependency>

--- a/wci/pom.xml
+++ b/wci/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-    <groupId>org.gatein.wci</groupId>
+    <groupId>org.exoplatform.gatein.wci</groupId>
     <artifactId>wci-parent</artifactId>
-    <version>2.6.x-PLF-SNAPSHOT</version>
+    <version>5.0.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>wci-wci</artifactId>


### PR DESCRIPTION
  * Maven groupId moved from org.gatein.pc to org.exoplatform.gatein.pc
  * Java packages are still org.gatein.pc

(see SWF-3871 for gatein projects)